### PR TITLE
Add ClinicalTrials.gov document downloader tool

### DIFF
--- a/clinical_trials_analyzer.R
+++ b/clinical_trials_analyzer.R
@@ -1,0 +1,373 @@
+#!/usr/bin/env Rscript
+# clinical_trials_analyzer.R
+#
+# Classifies ClinicalTrials.gov studies by:
+#   - Phase (1 / 2 / 3 / 4 / Other)
+#   - Therapeutic area (Oncology, CV, CNS, etc.)
+#   - Study type (DDI, Hepatic Impairment, BE, Pivotal, etc.)
+#
+# Dependencies: httr, jsonlite, (optional) writexl
+#   install.packages(c("httr", "jsonlite", "writexl"))
+#
+# Usage:
+#   source("clinical_trials_analyzer.R")
+#   df <- analyze_sponsor("Pfizer", doc_types = c("protocol","sap","icf"))
+#   print_summary(df)
+#   export_results(df, "pfizer_study_classification.csv")
+
+source("clinical_trials_downloader.R")  # reuses get_study_by_nct_id & search helpers
+
+# ---------------------------------------------------------------------------
+# Classification dictionaries
+# ---------------------------------------------------------------------------
+
+TA_KEYWORDS <- list(
+  "Oncology"                  = c("cancer","carcinoma","tumor","tumour","neoplasm",
+                                   "leukemia","leukaemia","lymphoma","melanoma","sarcoma",
+                                   "myeloma","glioma","glioblastoma","adenocarcinoma",
+                                   "malignant","metastatic","oncology","blastoma"),
+  "Cardiovascular"            = c("heart failure","hypertension","atrial fibrillation",
+                                   "coronary","myocardial","stroke","thrombosis",
+                                   "thromboembolism","arrhythmia","angina","cardiovascular",
+                                   "cardiac","ventricular","aortic","peripheral artery"),
+  "CNS / Neurology"           = c("alzheimer","parkinson","epilepsy","seizure",
+                                   "schizophrenia","depression","anxiety","bipolar",
+                                   "multiple sclerosis","migraine","neuropathy","dementia",
+                                   "neurological","psychiatric","autism","adhd",
+                                   "amyotrophic lateral","huntington"),
+  "Infectious Disease"        = c("hiv","aids","hepatitis","covid","sars-cov","bacterial",
+                                   "viral","infection","pneumonia","tuberculosis","malaria",
+                                   "influenza","fungal","sepsis","antibiotic","antiviral"),
+  "Immunology / Rheumatology" = c("rheumatoid arthritis","lupus","psoriasis","crohn",
+                                   "ulcerative colitis","inflammatory bowel","autoimmune",
+                                   "immunology","atopic dermatitis","spondylitis",
+                                   "juvenile arthritis","vasculitis","myositis"),
+  "Respiratory"               = c("asthma","copd","pulmonary","respiratory",
+                                   "cystic fibrosis","idiopathic pulmonary fibrosis",
+                                   "lung disease","bronchitis","bronchiectasis"),
+  "Endocrinology / Metabolic" = c("diabetes","obesity","thyroid","metabolic syndrome",
+                                   "dyslipidemia","hypercholesterolemia","nash",
+                                   "non-alcoholic steatohepatitis","insulin","hypoglycemia",
+                                   "fatty liver","steatosis"),
+  "Dermatology"               = c("dermatitis","eczema","acne","urticaria","alopecia",
+                                   "vitiligo","dermatology","psoriatic skin","rosacea"),
+  "Gastroenterology"          = c("gastroenterology","liver disease","cirrhosis","ibs",
+                                   "irritable bowel","gastric","intestinal","colitis",
+                                   "gastrointestinal","constipation","diarrhea","nausea"),
+  "Hematology"                = c("anemia","anaemia","hemophilia","sickle cell",
+                                   "thrombocytopenia","hematology","haematology",
+                                   "blood disorder","coagulation","myelodysplastic"),
+  "Ophthalmology"             = c("ophthalm","retinal","macular","glaucoma","eye disease",
+                                   "vision","diabetic retinopathy"),
+  "Rare Disease"              = c("rare disease","orphan drug","rare disorder",
+                                   "ultra-rare","rare condition")
+)
+
+STUDY_TYPE_PATTERNS <- list(
+  "First-in-Human (FIH)"       = c("first.in.human","first human","first-in-man","fih",
+                                    "first-in-healthy","first dose in human"),
+  "Single Ascending Dose (SAD)"= c("single ascending dose","single-ascending-dose","\\bsad\\b",
+                                    "single dose escalation","single-dose escalation"),
+  "Multiple Ascending Dose (MAD)"=c("multiple ascending dose","multiple-ascending-dose",
+                                    "\\bmad\\b","multiple dose escalation"),
+  "Drug-Drug Interaction (DDI)"= c("drug.drug interaction","\\bddi\\b","drug interaction",
+                                    "pharmacokinetic interaction","cyp.*inhibit","cyp.*induc",
+                                    "p-glycoprotein","transporter.*inhibit","inhibit.*cyp"),
+  "Hepatic Impairment"         = c("hepatic impairment","liver impairment",
+                                    "hepatic dysfunction","child.pugh","hepatic failure",
+                                    "liver failure"),
+  "Renal Impairment"           = c("renal impairment","kidney impairment","renal dysfunction",
+                                    "renal failure","\\begfr\\b","creatinine clearance",
+                                    "chronic kidney"),
+  "Food Effect"                = c("food effect","\\bfed\\b.*\\bfast","\\bfast.*\\bfed\\b",
+                                    "high.fat meal","food interaction","fed state","fasted state",
+                                    "effect of food"),
+  "Bioequivalence / BA"        = c("bioequivalence","\\bbe study\\b","bioavailability",
+                                    "\\bba/be\\b","relative bioavailability","absolute bioavailability",
+                                    "formulation.*comparison","reference.*test.*formulation"),
+  "Mass Balance / ADME"        = c("mass balance","radiolabeled","\\badme\\b","\\[14c\\]",
+                                    "carbon.14","radioactive","absorption.*distribution.*metabolism",
+                                    "excretion study"),
+  "QTc / Cardiac Safety"       = c("\\bqtc\\b","qt.*prolongation","cardiac.*repolarization",
+                                    "thorough qt","tqt"),
+  "Dose Finding / Ranging"     = c("dose.find","dose.rang","dose.response",
+                                    "dose.*optimal","optimal dose","dose.*selection"),
+  "Dose Escalation"            = c("dose escalat","\\bmtd\\b","maximum tolerated dose",
+                                    "dose.*expansion","escalating dose"),
+  "Pivotal / Confirmatory"     = c("pivotal","confirmatory","registration","phase 3.*efficacy",
+                                    "phase iii.*efficacy","approval.*trial","\\bphase 3\\b.*\\bprimary"),
+  "Proof of Concept (PoC)"     = c("proof.of.concept","\\bpoc\\b","proof.of.principle",
+                                    "exploratory.*efficacy","early.*efficacy","signal.*finding"),
+  "Open-Label Extension (OLE)" = c("open.label extension","\\bole\\b",
+                                    "long.term extension","extension study","extension phase"),
+  "Long-Term Safety"           = c("long.term safety","safety extension","safety.*follow.up",
+                                    "chronic.*safety","2.year.*safety","3.year.*safety"),
+  "Pediatric"                  = c("pediatric","paediatric","child.*patient","adolescent",
+                                    "neonatal","juvenile","age.*\\d+.*year.*child"),
+  "Geriatric / Elderly"        = c("geriatric","elderly","older adult","aged.*\\d{2,}",
+                                    "\\belderly\\b"),
+  "Special Population"         = c("special population","intrinsic factor","extrinsic factor",
+                                    "organ impairment"),
+  "Phase 2 Efficacy"           = c("phase 2.*efficacy","phase ii.*efficacy",
+                                    "\\bph2\\b.*efficacy","phase 2.*dose.*range"),
+  "Phase 3 Efficacy"           = c("phase 3.*efficacy","phase iii.*efficacy",
+                                    "\\bph3\\b.*efficacy","phase 3.*superiority",
+                                    "phase 3.*non-inferiority")
+)
+
+# ---------------------------------------------------------------------------
+# Metadata fetch (extended fields beyond the downloader's .parse_study)
+# ---------------------------------------------------------------------------
+
+get_study_metadata <- function(nct_id) {
+  nct_id <- toupper(trimws(nct_id))
+  url    <- paste0(BASE_API_URL, "/", nct_id)
+
+  resp <- tryCatch(
+    GET(url, API_HEADERS, query = list(format = "json"), timeout(30)),
+    error = function(e) NULL
+  )
+  if (is.null(resp) || http_error(resp)) return(NULL)
+
+  d <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
+  proto  <- d$protocolSection %||% list()
+  id_mod <- proto$identificationModule %||% list()
+  st_mod <- proto$statusModule         %||% list()
+  sp_mod <- proto$sponsorCollaboratorsModule %||% list()
+  dc_mod <- proto$descriptionModule    %||% list()
+  cn_mod <- proto$conditionsModule     %||% list()
+  de_mod <- proto$designModule         %||% list()
+  el_mod <- proto$eligibilityModule    %||% list()
+  ai_mod <- proto$armsInterventionsModule %||% list()
+  doc_mod <- d$documentSection$largeDocumentModule %||% list()
+  mesh   <- d$derivedSection$conditionBrowseModule$meshes %||% list()
+
+  # Flatten phases list to a string
+  phases <- unlist(de_mod$phases %||% list())
+  phases <- if (length(phases) == 0) "N/A" else paste(phases, collapse = " / ")
+
+  # Collect condition text + mesh terms for TA classification
+  conditions  <- unlist(cn_mod$conditions %||% list())
+  keywords    <- unlist(cn_mod$keywords   %||% list())
+  mesh_terms  <- sapply(mesh, function(m) m$term %||% "")
+  cond_text   <- tolower(paste(c(conditions, keywords, mesh_terms), collapse = " "))
+
+  # Collect text corpus for study-type classification
+  title       <- tolower(paste(id_mod$briefTitle %||% "",
+                               id_mod$officialTitle %||% ""))
+  summary     <- tolower(dc_mod$briefSummary %||% "")
+  detail      <- tolower(dc_mod$detailedDescription %||% "")
+  text_corpus <- paste(title, summary, detail)
+
+  # Healthy volunteers
+  healthy_vol <- el_mod$healthyVolunteers %||% ""
+
+  # Intervention names
+  interventions <- sapply(ai_mod$interventions %||% list(),
+                          function(x) x$name %||% "")
+
+  # Available document types
+  doc_types_avail <- sapply(doc_mod$largeDocs %||% list(),
+                            function(x) x$typeAbbrev %||% "")
+
+  list(
+    nct_id         = id_mod$nctId        %||% nct_id,
+    brief_title    = id_mod$briefTitle   %||% "",
+    official_title = id_mod$officialTitle %||% "",
+    lead_sponsor   = sp_mod$leadSponsor$name %||% "",
+    status         = st_mod$overallStatus %||% "",
+    start_date     = st_mod$startDateStruct$date %||% "",
+    study_type_raw = de_mod$studyType    %||% "",
+    phases         = phases,
+    phases_raw     = phases,
+    primary_purpose= de_mod$designInfo$primaryPurpose %||% "",
+    allocation     = de_mod$designInfo$allocation %||% "",
+    masking        = de_mod$designInfo$maskingInfo$masking %||% "",
+    intervention_model = de_mod$designInfo$interventionModel %||% "",
+    healthy_volunteers = healthy_vol,
+    conditions     = paste(conditions, collapse = "; "),
+    interventions  = paste(interventions, collapse = "; "),
+    doc_types      = paste(doc_types_avail, collapse = ", "),
+    cond_text      = cond_text,
+    text_corpus    = text_corpus
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Classifiers
+# ---------------------------------------------------------------------------
+
+classify_phase <- function(phases_raw) {
+  p <- toupper(phases_raw)
+  if (grepl("PHASE4|PHASE_4",  p)) return("Phase 4")
+  if (grepl("PHASE3|PHASE_3",  p)) return("Phase 3")
+  if (grepl("PHASE2|PHASE_2",  p)) return("Phase 2")
+  if (grepl("PHASE1|PHASE_1|EARLY_PHASE", p)) return("Phase 1")
+  if (p == "N/A" || nchar(trimws(p)) == 0)    return("N/A")
+  "Other"
+}
+
+classify_therapeutic_area <- function(meta) {
+  # Observational / registry studies with no real condition → Other
+  if (meta$study_type_raw == "OBSERVATIONAL" && nchar(meta$cond_text) < 10)
+    return("Observational / Other")
+
+  # Healthy volunteer-only studies
+  if (grepl("yes", tolower(meta$healthy_volunteers)) &&
+      !grepl("patient|subject with|diagnosed", meta$text_corpus))
+    return("Healthy Volunteer")
+
+  txt <- paste(meta$cond_text, tolower(meta$conditions))
+
+  for (ta in names(TA_KEYWORDS)) {
+    pats <- TA_KEYWORDS[[ta]]
+    if (any(sapply(pats, function(p) grepl(p, txt, ignore.case = TRUE, perl = TRUE))))
+      return(ta)
+  }
+  "Other"
+}
+
+classify_study_types <- function(meta) {
+  # Observational handled separately
+  if (meta$study_type_raw == "OBSERVATIONAL")
+    return("Observational / Registry")
+
+  corpus <- meta$text_corpus
+  matched <- character(0)
+
+  for (stype in names(STUDY_TYPE_PATTERNS)) {
+    pats <- STUDY_TYPE_PATTERNS[[stype]]
+    if (any(sapply(pats, function(p) grepl(p, corpus, ignore.case = TRUE, perl = TRUE))))
+      matched <- c(matched, stype)
+  }
+
+  if (length(matched) == 0) return("Other")
+  paste(matched, collapse = " | ")
+}
+
+# ---------------------------------------------------------------------------
+# Main analysis function
+# ---------------------------------------------------------------------------
+
+#' Classify a vector of NCT IDs and return a data frame.
+#'
+#' @param nct_ids  Character vector of NCT IDs.
+#' @return data.frame with one row per study.
+classify_studies <- function(nct_ids) {
+  n <- length(nct_ids)
+  message("Classifying ", n, " studies ...")
+  rows <- vector("list", n)
+
+  for (i in seq_along(nct_ids)) {
+    if (i %% 10 == 0 || i == n)
+      message("  ", i, "/", n, " ...")
+
+    meta <- get_study_metadata(nct_ids[[i]])
+    if (is.null(meta)) {
+      rows[[i]] <- data.frame(
+        nct_id = nct_ids[[i]], brief_title = NA, lead_sponsor = NA,
+        status = NA, start_date = NA, phases = NA, phase_group = NA,
+        therapeutic_area = NA, study_types = NA,
+        healthy_volunteers = NA, conditions = NA,
+        interventions = NA, doc_types_available = NA,
+        stringsAsFactors = FALSE
+      )
+      next
+    }
+
+    rows[[i]] <- data.frame(
+      nct_id              = meta$nct_id,
+      brief_title         = meta$brief_title,
+      lead_sponsor        = meta$lead_sponsor,
+      status              = meta$status,
+      start_date          = meta$start_date,
+      phases              = meta$phases,
+      phase_group         = classify_phase(meta$phases_raw),
+      therapeutic_area    = classify_therapeutic_area(meta),
+      study_types         = classify_study_types(meta),
+      healthy_volunteers  = meta$healthy_volunteers,
+      conditions          = meta$conditions,
+      interventions       = meta$interventions,
+      doc_types_available = meta$doc_types,
+      stringsAsFactors    = FALSE
+    )
+    Sys.sleep(0.4)
+  }
+
+  do.call(rbind, rows)
+}
+
+#' Search for a sponsor's studies with documents and classify them.
+#'
+#' @param sponsor    Character. Sponsor name, e.g. "Pfizer".
+#' @param doc_types  Character vector. "protocol", "sap", "icf".
+#' @param max_studies Integer or Inf.
+#' @return data.frame of classified studies.
+#'
+#' @examples
+#' df <- analyze_sponsor("Pfizer")
+#' print_summary(df)
+#' export_results(df, "pfizer_analysis.csv")
+analyze_sponsor <- function(sponsor,
+                            doc_types    = c("protocol", "sap", "icf"),
+                            max_studies  = Inf) {
+  message("\nSearching for ", sponsor, " studies with documents ...")
+  studies <- search_studies_with_documents(
+    sponsor     = sponsor,
+    doc_types   = doc_types,
+    max_studies = max_studies
+  )
+  if (length(studies) == 0) {
+    message("No studies found.")
+    return(invisible(NULL))
+  }
+  nct_ids <- sapply(studies, `[[`, "nct_id")
+  classify_studies(nct_ids)
+}
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+.tbl <- function(x, title) {
+  cat("\n", title, "\n", strrep("-", nchar(title)), "\n", sep = "")
+  t <- sort(table(x), decreasing = TRUE)
+  for (nm in names(t)) cat(sprintf("  %-45s %d\n", nm, t[[nm]]))
+}
+
+#' Print a summary of the classification data frame.
+print_summary <- function(df) {
+  cat("\n========================================\n")
+  cat(" CLINICAL TRIAL CLASSIFICATION SUMMARY\n")
+  cat("========================================\n")
+  cat("Total studies analysed:", nrow(df), "\n")
+
+  .tbl(df$phase_group,      "Studies by Phase")
+  .tbl(df$therapeutic_area, "Studies by Therapeutic Area")
+
+  # Study types — each cell can have multiple pipe-separated values; expand them
+  all_types <- unlist(strsplit(df$study_types[!is.na(df$study_types)], " \\| "))
+  .tbl(all_types, "Studies by Study Type  (multi-label)")
+
+  .tbl(df$status,           "Studies by Status")
+  cat("\n")
+  invisible(df)
+}
+
+#' Export classification results to CSV (and optionally Excel).
+#'
+#' @param df        data.frame from classify_studies() or analyze_sponsor().
+#' @param file      Output file path (CSV). An .xlsx is also written if writexl is installed.
+export_results <- function(df, file = "study_classification.csv") {
+  # Drop internal text columns before export
+  out <- df[, !names(df) %in% c("cond_text", "text_corpus"), drop = FALSE]
+  write.csv(out, file, row.names = FALSE)
+  message("CSV saved: ", normalizePath(file))
+
+  xlsx <- sub("\\.csv$", ".xlsx", file)
+  if (requireNamespace("writexl", quietly = TRUE)) {
+    writexl::write_xlsx(out, xlsx)
+    message("Excel saved: ", normalizePath(xlsx))
+  }
+  invisible(out)
+}

--- a/clinical_trials_analyzer.R
+++ b/clinical_trials_analyzer.R
@@ -371,3 +371,166 @@ export_results <- function(df, file = "study_classification.csv") {
   }
   invisible(out)
 }
+
+# ---------------------------------------------------------------------------
+# Folder organisation by phase and study type
+# ---------------------------------------------------------------------------
+
+PHASE_FOLDERS <- c(
+  "Phase 1" = "Phase_1",
+  "Phase 2" = "Phase_2",
+  "Phase 3" = "Phase_3",
+  "Phase 4" = "Phase_4",
+  "Other"   = "Other_Phase",
+  "N/A"     = "Phase_NA"
+)
+
+STUDY_TYPE_FOLDERS <- c(
+  "First-in-Human (FIH)"          = "FIH",
+  "Single Ascending Dose (SAD)"   = "SAD",
+  "Multiple Ascending Dose (MAD)" = "MAD",
+  "Drug-Drug Interaction (DDI)"   = "DDI",
+  "Hepatic Impairment"            = "Hepatic_Impairment",
+  "Renal Impairment"              = "Renal_Impairment",
+  "Food Effect"                   = "Food_Effect",
+  "Bioequivalence / BA"           = "Bioequivalence_BA",
+  "Mass Balance / ADME"           = "Mass_Balance_ADME",
+  "QTc / Cardiac Safety"          = "QTc_Cardiac_Safety",
+  "Dose Finding / Ranging"        = "Dose_Finding_Ranging",
+  "Dose Escalation"               = "Dose_Escalation",
+  "Pivotal / Confirmatory"        = "Pivotal_Confirmatory",
+  "Proof of Concept (PoC)"        = "Proof_of_Concept",
+  "Open-Label Extension (OLE)"    = "Open_Label_Extension",
+  "Long-Term Safety"              = "Long_Term_Safety",
+  "Pediatric"                     = "Pediatric",
+  "Geriatric / Elderly"           = "Geriatric_Elderly",
+  "Special Population"            = "Special_Population",
+  "Phase 2 Efficacy"              = "Phase_2_Efficacy",
+  "Phase 3 Efficacy"              = "Phase_3_Efficacy",
+  "Observational / Registry"      = "Observational_Registry",
+  "Other"                         = "Other_Study_Type"
+)
+
+.phase_folder <- function(phase_group) {
+  PHASE_FOLDERS[[phase_group %||% "N/A"]] %||% "Phase_NA"
+}
+
+# Return the folder name for the primary (first) matched study type
+.primary_type_folder <- function(study_types_str) {
+  if (is.na(study_types_str) || !nchar(trimws(study_types_str)))
+    return(STUDY_TYPE_FOLDERS[["Other"]])
+  primary <- trimws(strsplit(study_types_str, " \\| ")[[1]][1])
+  STUDY_TYPE_FOLDERS[[primary]] %||% gsub("[^A-Za-z0-9]", "_", primary)
+}
+
+#' Preview the folder structure that organize_by_classification() would create.
+#'
+#' @param df  data.frame from classify_studies() or analyze_sponsor().
+preview_organization <- function(df) {
+  tbl <- table(
+    Phase      = sapply(df$phase_group,  .phase_folder),
+    Study_Type = sapply(df$study_types, .primary_type_folder)
+  )
+  cat("\nFolder structure preview (Phase / Study Type — study count):\n")
+  cat(strrep("-", 60), "\n")
+  for (ph in rownames(tbl)) {
+    ph_total <- sum(tbl[ph, ])
+    cat(sprintf("  %s/  (%d studies)\n", ph, ph_total))
+    for (st in colnames(tbl)) {
+      if (tbl[ph, st] > 0)
+        cat(sprintf("    %-40s %d\n", paste0(st, "/"), tbl[ph, st]))
+    }
+  }
+  invisible(tbl)
+}
+
+#' Copy downloaded PDFs into Phase/StudyType/NCT_ID folder hierarchy.
+#'
+#' @param df         data.frame from classify_studies() or analyze_sponsor().
+#' @param source_dir Directory where PDFs were saved by search_and_download()
+#'                   (contains one sub-folder per NCT ID).
+#' @param output_dir Root of the organised output tree.
+#' @param copy       TRUE = copy files (safe); FALSE = move files (faster).
+#' @return Invisibly, a data.frame log of every file operation.
+#'
+#' @examples
+#' df <- analyze_sponsor("Pfizer")
+#' organize_by_classification(df, source_dir = "./pfizer_docs",
+#'                                output_dir  = "./pfizer_organized")
+organize_by_classification <- function(df,
+                                       source_dir,
+                                       output_dir = "./organized_docs",
+                                       copy       = TRUE) {
+  source_dir <- normalizePath(source_dir, mustWork = FALSE)
+  output_dir <- normalizePath(output_dir, mustWork = FALSE)
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+  log_rows <- list()
+  n_files  <- 0L
+  n_skip   <- 0L
+
+  for (i in seq_len(nrow(df))) {
+    row    <- df[i, ]
+    nct_id <- row$nct_id
+    if (is.na(nct_id) || !nchar(nct_id)) next
+
+    src_dir <- file.path(source_dir, nct_id)
+    if (!dir.exists(src_dir)) {
+      n_skip <- n_skip + 1L
+      log_rows[[length(log_rows) + 1]] <- data.frame(
+        nct_id = nct_id, file = NA, phase_folder = NA,
+        type_folder = NA, status = "no_source_folder", stringsAsFactors = FALSE
+      )
+      next
+    }
+
+    ph_folder  <- .phase_folder(row$phase_group)
+    typ_folder <- .primary_type_folder(row$study_types)
+    dst_dir    <- file.path(output_dir, ph_folder, typ_folder, nct_id)
+    dir.create(dst_dir, recursive = TRUE, showWarnings = FALSE)
+
+    files <- list.files(src_dir, full.names = TRUE, recursive = FALSE)
+    for (f in files) {
+      dst_file <- file.path(dst_dir, basename(f))
+      ok <- if (copy) file.copy(f, dst_file, overwrite = TRUE)
+            else      file.rename(f, dst_file)
+      n_files <- n_files + 1L
+      log_rows[[length(log_rows) + 1]] <- data.frame(
+        nct_id      = nct_id,
+        file        = basename(f),
+        phase_folder = ph_folder,
+        type_folder  = typ_folder,
+        status       = if (ok) "ok" else "failed",
+        stringsAsFactors = FALSE
+      )
+    }
+  }
+
+  # Write index with classification + destination path
+  index <- merge(
+    df[, c("nct_id","brief_title","lead_sponsor","phase_group",
+           "therapeutic_area","study_types","status","conditions",
+           "doc_types_available")],
+    data.frame(
+      nct_id       = sapply(df$nct_id, identity),
+      phase_folder = sapply(df$phase_group,  .phase_folder),
+      type_folder  = sapply(df$study_types, .primary_type_folder),
+      stringsAsFactors = FALSE
+    ),
+    by = "nct_id", all.x = TRUE
+  )
+  index$destination_path <- file.path(
+    output_dir, index$phase_folder, index$type_folder, index$nct_id
+  )
+  index_file <- file.path(output_dir, "study_index.csv")
+  write.csv(index, index_file, row.names = FALSE)
+
+  op <- if (copy) "copied" else "moved"
+  message("\nOrganisation complete.")
+  message("  Files ", op, ":          ", n_files)
+  message("  Studies skipped        ", n_skip, "  (not yet downloaded)")
+  message("  Output directory:      ", output_dir)
+  message("  Index CSV:             ", index_file)
+
+  invisible(do.call(rbind, log_rows))
+}

--- a/clinical_trials_downloader.R
+++ b/clinical_trials_downloader.R
@@ -21,11 +21,11 @@ BASE_API_URL <- "https://clinicaltrials.gov/api/v2/studies"
 CDN_BASE_URL <- "https://cdn.clinicaltrials.gov/large-docs"
 API_HEADERS  <- add_headers(`User-Agent` = "ClinicalTrialsDocDownloader/1.0 (R research tool)")
 
-DOC_FILTERS <- list(
-  protocol = "AREA[LargeDocHasProtocol]true",
-  sap      = "AREA[LargeDocHasSAP]true",
-  icf      = "AREA[LargeDocHasICF]true"
-)
+# aggFilters values used by the ClinicalTrials.gov API v2
+DOC_AGG_CODES <- list(protocol = "prot", sap = "sap", icf = "icf")
+
+# Fields to request so largeDocumentModule is included in every response
+API_FIELDS <- "NCTId,BriefTitle,LeadSponsorName,LargeDocumentModule"
 
 DOC_TYPE_LABELS <- c(
   Prot         = "Protocol",
@@ -78,7 +78,7 @@ get_study_by_nct_id <- function(nct_id) {
   url    <- paste0(BASE_API_URL, "/", nct_id)
 
   resp <- tryCatch(
-    GET(url, API_HEADERS, query = list(format = "json"), timeout(30)),
+    GET(url, API_HEADERS, query = list(format = "json", fields = API_FIELDS), timeout(30)),
     error = function(e) { message("Request failed: ", e$message); NULL }
   )
   if (is.null(resp) || http_error(resp)) {
@@ -105,13 +105,14 @@ search_studies_with_documents <- function(
     doc_types    = "protocol",
     max_studies  = 10
 ) {
-  filter_exprs   <- unlist(DOC_FILTERS[doc_types], use.names = FALSE)
-  advanced_filter <- paste(filter_exprs, collapse = " OR ")
+  agg_codes <- unlist(DOC_AGG_CODES[doc_types], use.names = FALSE)
+  agg_filter <- paste0("docs:", paste(agg_codes, collapse = ","))
 
   query <- list(
-    format            = "json",
-    pageSize          = min(max_studies, 100),
-    "filter.advanced" = advanced_filter
+    format     = "json",
+    pageSize   = min(max_studies, 100),
+    aggFilters = agg_filter,
+    fields     = API_FIELDS
   )
   if (!is.null(condition))    query[["query.cond"]]  <- condition
   if (!is.null(intervention)) query[["query.intr"]]  <- intervention

--- a/clinical_trials_downloader.R
+++ b/clinical_trials_downloader.R
@@ -96,50 +96,72 @@ get_study_by_nct_id <- function(nct_id) {
 #' @param intervention Character. Drug/intervention (e.g. "pembrolizumab").
 #' @param sponsor      Character. Sponsor name (e.g. "Pfizer").
 #' @param doc_types    Character vector. Any of "protocol", "sap", "icf".
-#' @param max_studies  Integer. Maximum results to return.
+#' @param max_studies  Integer or Inf. Cap on results; Inf fetches everything.
 #' @return List of parsed study records.
 search_studies_with_documents <- function(
     condition    = NULL,
     intervention = NULL,
     sponsor      = NULL,
     doc_types    = "protocol",
-    max_studies  = 10
+    max_studies  = Inf
 ) {
   agg_codes  <- unlist(DOC_AGG_CODES[doc_types], use.names = FALSE)
   agg_filter <- paste0("docs:", paste(agg_codes, collapse = ","))
 
   query <- list(
     format     = "json",
-    pageSize   = min(max_studies, 100),  # fetch exactly what we need in one call
+    pageSize   = 100,
     aggFilters = agg_filter
   )
   if (!is.null(condition))    query[["query.cond"]]  <- condition
   if (!is.null(intervention)) query[["query.intr"]]  <- intervention
   if (!is.null(sponsor))      query[["query.spons"]] <- sponsor
 
-  resp <- tryCatch(
-    GET(BASE_API_URL, API_HEADERS, query = query, timeout(30)),
-    error = function(e) { message("Request failed: ", e$message); NULL }
-  )
-  if (is.null(resp) || http_error(resp)) {
-    message("API error: HTTP ", status_code(resp))
-    return(list())
+  # Phase 1: paginate through search results to collect NCT IDs
+  nct_ids    <- character(0)
+  page_token <- NULL
+
+  repeat {
+    if (length(nct_ids) >= max_studies) break
+    if (!is.null(page_token)) query[["pageToken"]] <- page_token
+
+    resp <- tryCatch(
+      GET(BASE_API_URL, API_HEADERS, query = query, timeout(30)),
+      error = function(e) { message("Request failed: ", e$message); NULL }
+    )
+    if (is.null(resp) || http_error(resp)) {
+      message("API error: HTTP ", status_code(resp)); break
+    }
+
+    data  <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
+
+    if (length(nct_ids) == 0) {
+      total <- data$totalCount %||% "?"
+      message("  API reports ", total, " matching studies total.")
+    }
+
+    for (raw in data$studies %||% list()) {
+      id <- raw$protocolSection$identificationModule$nctId %||% ""
+      if (nchar(id) > 0) nct_ids <- c(nct_ids, id)
+      if (length(nct_ids) >= max_studies) break
+    }
+
+    page_token <- data$nextPageToken
+    if (is.null(page_token)) break
+    Sys.sleep(0.3)
   }
 
-  data  <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
-  batch <- data$studies %||% list()
-  batch <- batch[seq_len(min(length(batch), max_studies))]
+  if (length(nct_ids) == 0) return(list())
 
-  # Phase 2: the search endpoint returns trimmed data (no largeDocumentModule).
-  # Re-fetch each study individually to get the full record including doc metadata.
-  message("  Fetching full records for ", length(batch), " study/studies ...")
+  # Phase 2: fetch each study individually to get documentSection (not in search response)
+  message("  Fetching full records: 0/", length(nct_ids), " ...")
   studies <- list()
-  for (raw in batch) {
-    nct_id <- raw$protocolSection$identificationModule$nctId %||% ""
-    if (nchar(nct_id) == 0) next
-    full <- get_study_by_nct_id(nct_id)
+  for (i in seq_along(nct_ids)) {
+    if (i %% 10 == 0 || i == length(nct_ids))
+      message("  Fetching full records: ", i, "/", length(nct_ids), " ...")
+    full <- get_study_by_nct_id(nct_ids[[i]])
     if (!is.null(full)) studies <- c(studies, list(full))
-    Sys.sleep(0.3)
+    Sys.sleep(0.5)
   }
   studies
 }
@@ -284,8 +306,8 @@ search_and_download <- function(
     condition    = NULL,
     intervention = NULL,
     sponsor      = NULL,
-    doc_types    = "protocol",
-    max_studies  = 5,
+    doc_types    = c("protocol", "sap", "icf"),
+    max_studies  = Inf,
     download     = FALSE,
     output_dir   = "./clinical_trial_docs"
 ) {
@@ -294,7 +316,7 @@ search_and_download <- function(
   if (!is.null(intervention)) message("  Intervention: ", intervention)
   if (!is.null(sponsor))      message("  Sponsor:      ", sponsor)
   message("  Doc types:    ", paste(doc_types, collapse = ", "))
-  message("  Max studies:  ", max_studies)
+  message("  Max studies:  ", if (is.infinite(max_studies)) "all" else max_studies)
 
   studies <- search_studies_with_documents(
     condition    = condition,
@@ -326,12 +348,16 @@ search_and_download <- function(
   if (download) {
     dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
     message("Downloading to ", output_dir, "/ ...")
-    total <- 0L
-    for (s in studies) {
-      message("\n", s$nct_id, " - ", s$title)
-      total <- total + download_study_documents(s, output_dir, doc_types)
+    total_files <- 0L
+    for (i in seq_along(studies)) {
+      s <- studies[[i]]
+      message("\n[", i, "/", length(studies), "] ", s$nct_id, " - ", s$title)
+      total_files <- total_files + download_study_documents(s, output_dir, doc_types)
     }
-    message("\nTotal files downloaded: ", total)
+    message("\n--- Done ---")
+    message("Studies processed: ", length(studies))
+    message("Files downloaded:  ", total_files)
+    message("Output directory:  ", normalizePath(output_dir))
   }
 
   invisible(studies)

--- a/clinical_trials_downloader.R
+++ b/clinical_trials_downloader.R
@@ -105,51 +105,56 @@ search_studies_with_documents <- function(
     doc_types    = "protocol",
     max_studies  = Inf
 ) {
-  agg_codes  <- unlist(DOC_AGG_CODES[doc_types], use.names = FALSE)
-  agg_filter <- paste0("docs:", paste(agg_codes, collapse = ","))
+  agg_codes <- unlist(DOC_AGG_CODES[doc_types], use.names = FALSE)
 
-  query <- list(
-    format     = "json",
-    pageSize   = 100,
-    aggFilters = agg_filter
-  )
-  if (!is.null(condition))    query[["query.cond"]]  <- condition
-  if (!is.null(intervention)) query[["query.intr"]]  <- intervention
-  if (!is.null(sponsor))      query[["query.spons"]] <- sponsor
+  base_query <- list(format = "json", pageSize = 100)
+  if (!is.null(condition))    base_query[["query.cond"]]  <- condition
+  if (!is.null(intervention)) base_query[["query.intr"]]  <- intervention
+  if (!is.null(sponsor))      base_query[["query.spons"]] <- sponsor
 
-  # Phase 1: paginate through search results to collect NCT IDs
-  nct_ids    <- character(0)
-  page_token <- NULL
+  # Phase 1: one search per doc type (API rejects combined aggFilters like docs:prot,sap,icf)
+  # Merge and deduplicate NCT IDs across all searches.
+  nct_ids <- character(0)
 
-  repeat {
+  for (code in agg_codes) {
+    query      <- c(base_query, list(aggFilters = paste0("docs:", code)))
+    page_token <- NULL
+    type_ids   <- character(0)
+
+    repeat {
+      if (length(nct_ids) + length(type_ids) >= max_studies) break
+      if (!is.null(page_token)) query[["pageToken"]] <- page_token
+
+      resp <- tryCatch(
+        GET(BASE_API_URL, API_HEADERS, query = query, timeout(30)),
+        error = function(e) { message("Request failed: ", e$message); NULL }
+      )
+      if (is.null(resp) || http_error(resp)) {
+        message("API error (docs:", code, "): HTTP ", status_code(resp)); break
+      }
+
+      data <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
+
+      if (length(type_ids) == 0) {
+        message("  docs:", code, " — API reports ", data$totalCount %||% "?", " studies.")
+      }
+
+      for (raw in data$studies %||% list()) {
+        id <- raw$protocolSection$identificationModule$nctId %||% ""
+        if (nchar(id) > 0) type_ids <- c(type_ids, id)
+      }
+
+      page_token <- data$nextPageToken
+      if (is.null(page_token)) break
+      Sys.sleep(0.3)
+    }
+
+    nct_ids <- unique(c(nct_ids, type_ids))
     if (length(nct_ids) >= max_studies) break
-    if (!is.null(page_token)) query[["pageToken"]] <- page_token
-
-    resp <- tryCatch(
-      GET(BASE_API_URL, API_HEADERS, query = query, timeout(30)),
-      error = function(e) { message("Request failed: ", e$message); NULL }
-    )
-    if (is.null(resp) || http_error(resp)) {
-      message("API error: HTTP ", status_code(resp)); break
-    }
-
-    data  <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
-
-    if (length(nct_ids) == 0) {
-      total <- data$totalCount %||% "?"
-      message("  API reports ", total, " matching studies total.")
-    }
-
-    for (raw in data$studies %||% list()) {
-      id <- raw$protocolSection$identificationModule$nctId %||% ""
-      if (nchar(id) > 0) nct_ids <- c(nct_ids, id)
-      if (length(nct_ids) >= max_studies) break
-    }
-
-    page_token <- data$nextPageToken
-    if (is.null(page_token)) break
-    Sys.sleep(0.3)
   }
+
+  nct_ids <- nct_ids[seq_len(min(length(nct_ids), max_studies))]
+  message("  Total unique studies across all doc types: ", length(nct_ids))
 
   if (length(nct_ids) == 0) return(list())
 

--- a/clinical_trials_downloader.R
+++ b/clinical_trials_downloader.R
@@ -128,10 +128,20 @@ search_studies_with_documents <- function(
 
   data  <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
   batch <- data$studies %||% list()
+  batch <- batch[seq_len(min(length(batch), max_studies))]
 
-  # aggFilters already guarantees these studies have the requested doc types;
-  # parse and return without re-checking docs (avoids infinite pagination)
-  lapply(batch[seq_len(min(length(batch), max_studies))], .parse_study)
+  # Phase 2: the search endpoint returns trimmed data (no largeDocumentModule).
+  # Re-fetch each study individually to get the full record including doc metadata.
+  message("  Fetching full records for ", length(batch), " study/studies ...")
+  studies <- list()
+  for (raw in batch) {
+    nct_id <- raw$protocolSection$identificationModule$nctId %||% ""
+    if (nchar(nct_id) == 0) next
+    full <- get_study_by_nct_id(nct_id)
+    if (!is.null(full)) studies <- c(studies, list(full))
+    Sys.sleep(0.3)
+  }
+  studies
 }
 
 # ---------------------------------------------------------------------------

--- a/clinical_trials_downloader.R
+++ b/clinical_trials_downloader.R
@@ -41,10 +41,10 @@ DOC_TYPE_LABELS <- c(
 # ---------------------------------------------------------------------------
 
 .parse_study <- function(study) {
-  proto      <- study$protocolSection
-  id_mod     <- proto$identificationModule
+  proto       <- study$protocolSection
+  id_mod      <- proto$identificationModule
   sponsor_mod <- proto$sponsorCollaboratorsModule
-  docs_mod   <- proto$largeDocumentModule
+  docs_mod    <- study$documentSection$largeDocumentModule  # NOT under protocolSection
 
   list(
     nct_id       = id_mod$nctId %||% "",

--- a/clinical_trials_downloader.R
+++ b/clinical_trials_downloader.R
@@ -1,0 +1,364 @@
+#!/usr/bin/env Rscript
+# ClinicalTrials.gov Document Downloader (R version)
+#
+# Downloads study documents (protocols, SAPs, informed consent forms)
+# from ClinicalTrials.gov using the API v2.
+#
+# Dependencies: httr, jsonlite
+#   install.packages(c("httr", "jsonlite"))
+#
+# Usage:
+#   source("clinical_trials_downloader.R")
+#   download_study_docs("NCT04280705")
+#   search_and_download(condition = "diabetes", doc_types = "protocol", max_studies = 5)
+
+suppressPackageStartupMessages({
+  library(httr)
+  library(jsonlite)
+})
+
+BASE_API_URL <- "https://clinicaltrials.gov/api/v2/studies"
+CDN_BASE_URL <- "https://cdn.clinicaltrials.gov/large-docs"
+API_HEADERS  <- add_headers(`User-Agent` = "ClinicalTrialsDocDownloader/1.0 (R research tool)")
+
+DOC_FILTERS <- list(
+  protocol = "AREA[LargeDocHasProtocol]true",
+  sap      = "AREA[LargeDocHasSAP]true",
+  icf      = "AREA[LargeDocHasICF]true"
+)
+
+DOC_TYPE_LABELS <- c(
+  Prot         = "Protocol",
+  SAP          = "Statistical Analysis Plan",
+  ICF          = "Informed Consent Form",
+  Prot_SAP     = "Protocol + SAP",
+  Prot_ICF     = "Protocol + ICF",
+  Prot_SAP_ICF = "Protocol + SAP + ICF"
+)
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+.parse_study <- function(study) {
+  proto      <- study$protocolSection
+  id_mod     <- proto$identificationModule
+  sponsor_mod <- proto$sponsorCollaboratorsModule
+  docs_mod   <- proto$largeDocumentModule
+
+  list(
+    nct_id       = id_mod$nctId %||% "",
+    title        = id_mod$briefTitle %||% "",
+    lead_sponsor = sponsor_mod$leadSponsor$name %||% "Unknown",
+    docs         = docs_mod$largeDocs %||% list()
+  )
+}
+
+# Null-coalescing operator
+`%||%` <- function(x, y) if (!is.null(x)) x else y
+
+.doc_matches_filter <- function(type_abbrev, doc_type_filter) {
+  any(
+    ("protocol" %in% doc_type_filter & grepl("Prot", type_abbrev)),
+    ("sap"      %in% doc_type_filter & grepl("SAP",  type_abbrev)),
+    ("icf"      %in% doc_type_filter & grepl("ICF",  type_abbrev))
+  )
+}
+
+# ---------------------------------------------------------------------------
+# API functions
+# ---------------------------------------------------------------------------
+
+#' Fetch document metadata for a single study by NCT ID.
+#'
+#' @param nct_id  Character. NCT identifier, e.g. "NCT04280705".
+#' @return Named list with nct_id, title, lead_sponsor, docs, or NULL on error.
+get_study_by_nct_id <- function(nct_id) {
+  nct_id <- toupper(trimws(nct_id))
+  url    <- paste0(BASE_API_URL, "/", nct_id)
+
+  resp <- tryCatch(
+    GET(url, API_HEADERS, query = list(format = "json"), timeout(30)),
+    error = function(e) { message("Request failed: ", e$message); NULL }
+  )
+  if (is.null(resp) || http_error(resp)) {
+    message("Could not fetch ", nct_id, ": HTTP ", status_code(resp))
+    return(NULL)
+  }
+
+  data <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
+  .parse_study(data)
+}
+
+#' Search for studies with uploaded documents.
+#'
+#' @param condition    Character. Disease/condition (e.g. "lung cancer").
+#' @param intervention Character. Drug/intervention (e.g. "pembrolizumab").
+#' @param sponsor      Character. Sponsor name (e.g. "Pfizer").
+#' @param doc_types    Character vector. Any of "protocol", "sap", "icf".
+#' @param max_studies  Integer. Maximum results to return.
+#' @return List of parsed study records.
+search_studies_with_documents <- function(
+    condition    = NULL,
+    intervention = NULL,
+    sponsor      = NULL,
+    doc_types    = "protocol",
+    max_studies  = 10
+) {
+  filter_exprs   <- unlist(DOC_FILTERS[doc_types], use.names = FALSE)
+  advanced_filter <- paste(filter_exprs, collapse = " OR ")
+
+  query <- list(
+    format            = "json",
+    pageSize          = min(max_studies, 100),
+    "filter.advanced" = advanced_filter
+  )
+  if (!is.null(condition))    query[["query.cond"]]  <- condition
+  if (!is.null(intervention)) query[["query.intr"]]  <- intervention
+  if (!is.null(sponsor))      query[["query.spons"]] <- sponsor
+
+  studies    <- list()
+  page_token <- NULL
+
+  repeat {
+    if (length(studies) >= max_studies) break
+    if (!is.null(page_token)) query[["pageToken"]] <- page_token
+
+    resp <- tryCatch(
+      GET(BASE_API_URL, API_HEADERS, query = query, timeout(30)),
+      error = function(e) { message("Request failed: ", e$message); NULL }
+    )
+    if (is.null(resp) || http_error(resp)) {
+      message("API error: HTTP ", status_code(resp))
+      break
+    }
+
+    data  <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
+    batch <- data$studies %||% list()
+    if (length(batch) == 0) break
+
+    for (raw in batch) {
+      if (length(studies) >= max_studies) break
+      parsed <- .parse_study(raw)
+      if (length(parsed$docs) > 0) studies <- c(studies, list(parsed))
+    }
+
+    page_token <- data$nextPageToken
+    if (is.null(page_token)) break
+
+    Sys.sleep(0.4)  # respect rate limit
+  }
+
+  studies
+}
+
+# ---------------------------------------------------------------------------
+# Download functions
+# ---------------------------------------------------------------------------
+
+#' Download one document from the ClinicalTrials.gov CDN.
+#'
+#' URL pattern: https://cdn.clinicaltrials.gov/large-docs/{last2}/{NCTId}/{filename}
+#'
+#' @param nct_id   Character. NCT identifier.
+#' @param filename Character. Document filename from the API.
+#' @param dest_dir Character or path. Directory to save the file.
+#' @return TRUE on success, FALSE on failure.
+download_document <- function(nct_id, filename, dest_dir) {
+  last2    <- substr(nct_id, nchar(nct_id) - 1, nchar(nct_id))
+  url      <- paste(CDN_BASE_URL, last2, nct_id, filename, sep = "/")
+  dest     <- file.path(dest_dir, filename)
+
+  resp <- tryCatch(
+    GET(url, API_HEADERS, timeout(120), write_disk(dest, overwrite = TRUE)),
+    error = function(e) { message("    Download failed: ", e$message); NULL }
+  )
+
+  if (is.null(resp) || http_error(resp)) {
+    message("    Failed to download ", filename, ": HTTP ", status_code(resp))
+    return(FALSE)
+  }
+
+  size_kb <- round(file.info(dest)$size / 1024)
+  message("    Saved: ", dest, "  (", size_kb, " KB)")
+  TRUE
+}
+
+#' Download all matching documents for one study.
+#'
+#' @param study          Named list from get_study_by_nct_id() or search results.
+#' @param output_dir     Character. Root output directory; a sub-folder per NCT ID is created.
+#' @param doc_type_filter Character vector or NULL. Filter to "protocol", "sap", "icf".
+#' @return Integer count of files downloaded.
+download_study_documents <- function(study, output_dir = "./clinical_trial_docs",
+                                     doc_type_filter = NULL) {
+  nct_id   <- study$nct_id
+  docs     <- study$docs
+
+  if (length(docs) == 0) {
+    message("  No documents available for ", nct_id)
+    return(0L)
+  }
+
+  study_dir <- file.path(output_dir, nct_id)
+  dir.create(study_dir, recursive = TRUE, showWarnings = FALSE)
+
+  downloaded <- 0L
+  for (doc in docs) {
+    type_abbrev <- doc$typeAbbrev %||% ""
+    filename    <- doc$filename   %||% ""
+    label       <- doc$label      %||% DOC_TYPE_LABELS[type_abbrev] %||% type_abbrev
+    doc_date    <- doc$date       %||% "N/A"
+
+    if (!is.null(doc_type_filter) && !.doc_matches_filter(type_abbrev, doc_type_filter)) next
+    if (nchar(filename) == 0) {
+      message("  [", type_abbrev, "] ", label, " — no filename, skipping")
+      next
+    }
+
+    message("  [", type_abbrev, "] ", label, "  (date: ", doc_date, ")  -> ", filename)
+    if (download_document(nct_id, filename, study_dir)) downloaded <- downloaded + 1L
+  }
+
+  downloaded
+}
+
+# ---------------------------------------------------------------------------
+# High-level convenience functions
+# ---------------------------------------------------------------------------
+
+#' Download documents for a specific NCT ID.
+#'
+#' @param nct_id         Character. E.g. "NCT04280705".
+#' @param doc_types      Character vector or NULL (all). E.g. c("protocol", "sap").
+#' @param output_dir     Character. Where to save files.
+#' @return Invisibly, the number of files downloaded.
+#'
+#' @examples
+#' download_study_docs("NCT04280705")
+#' download_study_docs("NCT04280705", doc_types = "protocol", output_dir = "~/trials")
+download_study_docs <- function(nct_id,
+                                doc_types  = NULL,
+                                output_dir = "./clinical_trial_docs") {
+  nct_id <- toupper(trimws(nct_id))
+  message("\nFetching metadata for ", nct_id, " ...")
+  study <- get_study_by_nct_id(nct_id)
+
+  if (is.null(study)) {
+    message("Study not found or API error.")
+    return(invisible(0L))
+  }
+
+  message("\n  Title:   ", study$title)
+  message("  Sponsor: ", study$lead_sponsor)
+  message("  Docs:    ", length(study$docs), " record(s) found")
+
+  if (length(study$docs) == 0) {
+    message("\nNo documents are available for this study.")
+    return(invisible(0L))
+  }
+
+  message("\nAvailable documents:")
+  for (doc in study$docs) {
+    ta    <- doc$typeAbbrev %||% "?"
+    label <- doc$label %||% DOC_TYPE_LABELS[ta] %||% ta
+    fname <- doc$filename %||% "no filename"
+    message("  [", ta, "] ", label, "  (", fname, ")")
+  }
+
+  message("\nDownloading to ", file.path(output_dir, nct_id), "/ ...")
+  n <- download_study_documents(study, output_dir, doc_types)
+  message("\n", n, " file(s) downloaded.")
+  invisible(n)
+}
+
+#' Search ClinicalTrials.gov and optionally download matching documents.
+#'
+#' @param condition    Character or NULL.
+#' @param intervention Character or NULL.
+#' @param sponsor      Character or NULL.
+#' @param doc_types    Character vector. Default "protocol".
+#' @param max_studies  Integer. Default 5.
+#' @param download     Logical. Download files after listing? Default FALSE.
+#' @param output_dir   Character. Where to save files.
+#' @return Invisibly, a list of matched study records.
+#'
+#' @examples
+#' search_and_download(condition = "diabetes", doc_types = "protocol")
+#' search_and_download(condition = "cancer", sponsor = "Pfizer",
+#'                     doc_types = c("protocol", "sap"), max_studies = 10,
+#'                     download = TRUE)
+search_and_download <- function(
+    condition    = NULL,
+    intervention = NULL,
+    sponsor      = NULL,
+    doc_types    = "protocol",
+    max_studies  = 5,
+    download     = FALSE,
+    output_dir   = "./clinical_trial_docs"
+) {
+  message("\nSearching ClinicalTrials.gov ...")
+  if (!is.null(condition))    message("  Condition:    ", condition)
+  if (!is.null(intervention)) message("  Intervention: ", intervention)
+  if (!is.null(sponsor))      message("  Sponsor:      ", sponsor)
+  message("  Doc types:    ", paste(doc_types, collapse = ", "))
+  message("  Max studies:  ", max_studies)
+
+  studies <- search_studies_with_documents(
+    condition    = condition,
+    intervention = intervention,
+    sponsor      = sponsor,
+    doc_types    = doc_types,
+    max_studies  = max_studies
+  )
+
+  if (length(studies) == 0) {
+    message("\nNo matching studies found.")
+    return(invisible(list()))
+  }
+
+  message("\nFound ", length(studies), " study/studies with documents:\n")
+  for (i in seq_along(studies)) {
+    s <- studies[[i]]
+    message(i, ". ", s$nct_id, ": ", s$title)
+    message("   Sponsor: ", s$lead_sponsor)
+    for (doc in s$docs) {
+      ta    <- doc$typeAbbrev %||% "?"
+      label <- doc$label %||% DOC_TYPE_LABELS[ta] %||% ta
+      fname <- doc$filename %||% "no filename"
+      message("   [", ta, "] ", label, "  (", fname, ")")
+    }
+    message()
+  }
+
+  if (download) {
+    dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+    message("Downloading to ", output_dir, "/ ...")
+    total <- 0L
+    for (s in studies) {
+      message("\n", s$nct_id, " - ", s$title)
+      total <- total + download_study_documents(s, output_dir, doc_types)
+    }
+    message("\nTotal files downloaded: ", total)
+  }
+
+  invisible(studies)
+}
+
+# ---------------------------------------------------------------------------
+# Run as a script (Rscript clinical_trials_downloader.R NCT04280705)
+# ---------------------------------------------------------------------------
+if (!interactive()) {
+  args <- commandArgs(trailingOnly = TRUE)
+  if (length(args) == 0) {
+    cat("Usage:\n")
+    cat("  Rscript clinical_trials_downloader.R <NCT_ID> [output_dir]\n\n")
+    cat("Examples:\n")
+    cat("  Rscript clinical_trials_downloader.R NCT04280705\n")
+    cat("  Rscript clinical_trials_downloader.R NCT04280705 ~/my_trials\n")
+    quit(status = 1)
+  }
+  nct_id     <- args[1]
+  output_dir <- if (length(args) >= 2) args[2] else "./clinical_trial_docs"
+  download_study_docs(nct_id, output_dir = output_dir)
+}

--- a/clinical_trials_downloader.R
+++ b/clinical_trials_downloader.R
@@ -24,8 +24,8 @@ API_HEADERS  <- add_headers(`User-Agent` = "ClinicalTrialsDocDownloader/1.0 (R r
 # aggFilters values used by the ClinicalTrials.gov API v2
 DOC_AGG_CODES <- list(protocol = "prot", sap = "sap", icf = "icf")
 
-# Fields to request so largeDocumentModule is included in every response
-API_FIELDS <- "NCTId,BriefTitle,LeadSponsorName,LargeDocumentModule"
+# Fields to request — omit to get full response including largeDocumentModule
+API_FIELDS <- NULL
 
 DOC_TYPE_LABELS <- c(
   Prot         = "Protocol",
@@ -78,7 +78,7 @@ get_study_by_nct_id <- function(nct_id) {
   url    <- paste0(BASE_API_URL, "/", nct_id)
 
   resp <- tryCatch(
-    GET(url, API_HEADERS, query = list(format = "json", fields = API_FIELDS), timeout(30)),
+    GET(url, API_HEADERS, query = list(format = "json"), timeout(30)),
     error = function(e) { message("Request failed: ", e$message); NULL }
   )
   if (is.null(resp) || http_error(resp)) {
@@ -105,52 +105,33 @@ search_studies_with_documents <- function(
     doc_types    = "protocol",
     max_studies  = 10
 ) {
-  agg_codes <- unlist(DOC_AGG_CODES[doc_types], use.names = FALSE)
+  agg_codes  <- unlist(DOC_AGG_CODES[doc_types], use.names = FALSE)
   agg_filter <- paste0("docs:", paste(agg_codes, collapse = ","))
 
   query <- list(
     format     = "json",
-    pageSize   = min(max_studies, 100),
-    aggFilters = agg_filter,
-    fields     = API_FIELDS
+    pageSize   = min(max_studies, 100),  # fetch exactly what we need in one call
+    aggFilters = agg_filter
   )
   if (!is.null(condition))    query[["query.cond"]]  <- condition
   if (!is.null(intervention)) query[["query.intr"]]  <- intervention
   if (!is.null(sponsor))      query[["query.spons"]] <- sponsor
 
-  studies    <- list()
-  page_token <- NULL
-
-  repeat {
-    if (length(studies) >= max_studies) break
-    if (!is.null(page_token)) query[["pageToken"]] <- page_token
-
-    resp <- tryCatch(
-      GET(BASE_API_URL, API_HEADERS, query = query, timeout(30)),
-      error = function(e) { message("Request failed: ", e$message); NULL }
-    )
-    if (is.null(resp) || http_error(resp)) {
-      message("API error: HTTP ", status_code(resp))
-      break
-    }
-
-    data  <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
-    batch <- data$studies %||% list()
-    if (length(batch) == 0) break
-
-    for (raw in batch) {
-      if (length(studies) >= max_studies) break
-      parsed <- .parse_study(raw)
-      if (length(parsed$docs) > 0) studies <- c(studies, list(parsed))
-    }
-
-    page_token <- data$nextPageToken
-    if (is.null(page_token)) break
-
-    Sys.sleep(0.4)  # respect rate limit
+  resp <- tryCatch(
+    GET(BASE_API_URL, API_HEADERS, query = query, timeout(30)),
+    error = function(e) { message("Request failed: ", e$message); NULL }
+  )
+  if (is.null(resp) || http_error(resp)) {
+    message("API error: HTTP ", status_code(resp))
+    return(list())
   }
 
-  studies
+  data  <- fromJSON(content(resp, "text", encoding = "UTF-8"), simplifyVector = FALSE)
+  batch <- data$studies %||% list()
+
+  # aggFilters already guarantees these studies have the requested doc types;
+  # parse and return without re-checking docs (avoids infinite pagination)
+  lapply(batch[seq_len(min(length(batch), max_studies))], .parse_study)
 }
 
 # ---------------------------------------------------------------------------

--- a/clinical_trials_downloader.py
+++ b/clinical_trials_downloader.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""
+ClinicalTrials.gov Document Downloader
+
+Searches ClinicalTrials.gov for studies with uploaded documents (protocols,
+Statistical Analysis Plans, Informed Consent Forms) and downloads them.
+
+Usage:
+  # Download docs for a specific study:
+  python clinical_trials_downloader.py download NCT04280705
+
+  # Search and list studies with protocols:
+  python clinical_trials_downloader.py search --condition "diabetes" --doc-types protocol
+
+  # Search and download:
+  python clinical_trials_downloader.py search --condition "cancer" --doc-types protocol sap --download
+"""
+
+import os
+import sys
+import time
+import argparse
+import requests
+from pathlib import Path
+from typing import Optional, List, Dict
+
+BASE_API_URL = "https://clinicaltrials.gov/api/v2/studies"
+CDN_BASE_URL = "https://cdn.clinicaltrials.gov/large-docs"
+
+HEADERS = {"User-Agent": "ClinicalTrialsDocDownloader/1.0 (research tool)"}
+
+# Essie query expressions for filtering studies by document type
+DOC_FILTERS = {
+    "protocol": "AREA[LargeDocHasProtocol]true",
+    "sap":      "AREA[LargeDocHasSAP]true",
+    "icf":      "AREA[LargeDocHasICF]true",
+}
+
+DOC_TYPE_LABELS = {
+    "Prot":         "Protocol",
+    "SAP":          "Statistical Analysis Plan",
+    "ICF":          "Informed Consent Form",
+    "Prot_SAP":     "Protocol + SAP",
+    "Prot_ICF":     "Protocol + ICF",
+    "Prot_SAP_ICF": "Protocol + SAP + ICF",
+}
+
+
+def _parse_study(study: dict) -> dict:
+    """Extract relevant fields from a raw API study record."""
+    protocol = study.get("protocolSection", {})
+    id_mod = protocol.get("identificationModule", {})
+    sponsor_mod = protocol.get("sponsorCollaboratorsModule", {})
+    docs_mod = protocol.get("largeDocumentModule", {})
+
+    return {
+        "nct_id":      id_mod.get("nctId", ""),
+        "title":       id_mod.get("briefTitle", ""),
+        "lead_sponsor": sponsor_mod.get("leadSponsor", {}).get("name", "Unknown"),
+        "docs":        docs_mod.get("largeDocs", []),
+    }
+
+
+def search_studies_with_documents(
+    condition: Optional[str] = None,
+    intervention: Optional[str] = None,
+    sponsor: Optional[str] = None,
+    doc_types: Optional[List[str]] = None,
+    max_studies: int = 10,
+) -> List[Dict]:
+    """
+    Search ClinicalTrials.gov for studies that have uploaded documents.
+
+    Args:
+        condition:   Disease/condition (e.g. "lung cancer")
+        intervention: Drug or intervention (e.g. "pembrolizumab")
+        sponsor:     Sponsor name (e.g. "Pfizer")
+        doc_types:   One or more of "protocol", "sap", "icf"
+        max_studies: Cap on results returned
+
+    Returns:
+        List of parsed study dicts with 'nct_id', 'title', 'lead_sponsor', 'docs'.
+    """
+    if not doc_types:
+        doc_types = ["protocol"]
+
+    filter_exprs = [DOC_FILTERS[dt] for dt in doc_types if dt in DOC_FILTERS]
+    advanced_filter = " OR ".join(filter_exprs)
+
+    params: dict = {
+        "format":           "json",
+        "pageSize":         min(max_studies, 100),
+        "filter.advanced":  advanced_filter,
+    }
+
+    if condition:
+        params["query.cond"] = condition
+    if intervention:
+        params["query.intr"] = intervention
+    if sponsor:
+        params["query.spons"] = sponsor
+
+    studies = []
+    page_token: Optional[str] = None
+
+    while len(studies) < max_studies:
+        if page_token:
+            params["pageToken"] = page_token
+
+        try:
+            resp = requests.get(BASE_API_URL, params=params, headers=HEADERS, timeout=30)
+            resp.raise_for_status()
+            data = resp.json()
+        except requests.RequestException as exc:
+            print(f"API error: {exc}")
+            break
+
+        for raw in data.get("studies", []):
+            if len(studies) >= max_studies:
+                break
+            parsed = _parse_study(raw)
+            if parsed["docs"]:
+                studies.append(parsed)
+
+        page_token = data.get("nextPageToken")
+        if not page_token:
+            break
+
+        time.sleep(0.4)  # stay well under the ~50 req/min rate limit
+
+    return studies
+
+
+def get_study_by_nct_id(nct_id: str) -> Optional[Dict]:
+    """Fetch document metadata for a single study by NCT ID."""
+    url = f"{BASE_API_URL}/{nct_id}"
+    try:
+        resp = requests.get(url, params={"format": "json"}, headers=HEADERS, timeout=30)
+        resp.raise_for_status()
+        return _parse_study(resp.json())
+    except requests.RequestException as exc:
+        print(f"Failed to fetch {nct_id}: {exc}")
+        return None
+
+
+def _doc_matches_filter(type_abbrev: str, doc_type_filter: List[str]) -> bool:
+    """Return True if the doc type matches any of the requested filter keys."""
+    for dt in doc_type_filter:
+        if dt == "protocol" and "Prot" in type_abbrev:
+            return True
+        if dt == "sap" and "SAP" in type_abbrev:
+            return True
+        if dt == "icf" and "ICF" in type_abbrev:
+            return True
+    return False
+
+
+def download_document(nct_id: str, filename: str, dest_dir: Path) -> bool:
+    """
+    Download one document from the ClinicalTrials.gov CDN.
+
+    URL pattern: https://cdn.clinicaltrials.gov/large-docs/{last2}/{NCTId}/{filename}
+    """
+    last2 = nct_id[-2:]
+    url = f"{CDN_BASE_URL}/{last2}/{nct_id}/{filename}"
+    dest = dest_dir / filename
+
+    try:
+        resp = requests.get(url, headers=HEADERS, timeout=120, stream=True)
+        resp.raise_for_status()
+        with open(dest, "wb") as fh:
+            for chunk in resp.iter_content(chunk_size=8192):
+                fh.write(chunk)
+        size_kb = dest.stat().st_size // 1024
+        print(f"    Saved: {dest}  ({size_kb} KB)")
+        return True
+    except requests.RequestException as exc:
+        print(f"    Download failed for {filename}: {exc}")
+        return False
+
+
+def download_study_documents(
+    study: Dict,
+    output_dir: Path,
+    doc_type_filter: Optional[List[str]] = None,
+) -> int:
+    """
+    Download all matching documents for a study into output_dir/{nct_id}/.
+
+    Returns the number of files successfully downloaded.
+    """
+    nct_id = study["nct_id"]
+    docs = study.get("docs", [])
+
+    if not docs:
+        print(f"  No documents available for {nct_id}.")
+        return 0
+
+    study_dir = output_dir / nct_id
+    study_dir.mkdir(parents=True, exist_ok=True)
+
+    downloaded = 0
+    for doc in docs:
+        type_abbrev = doc.get("typeAbbrev", "")
+        filename = doc.get("filename", "")
+        label = doc.get("label", DOC_TYPE_LABELS.get(type_abbrev, type_abbrev))
+        doc_date = doc.get("date", "N/A")
+
+        if doc_type_filter and not _doc_matches_filter(type_abbrev, doc_type_filter):
+            continue
+
+        if not filename:
+            print(f"  [{type_abbrev}] {label} — no filename, skipping")
+            continue
+
+        print(f"  [{type_abbrev}] {label}  (date: {doc_date})  -> {filename}")
+        if download_document(nct_id, filename, study_dir):
+            downloaded += 1
+
+    return downloaded
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def cmd_download(args):
+    nct_id = args.nct_id.strip().upper()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print(f"\nFetching metadata for {nct_id} ...")
+    study = get_study_by_nct_id(nct_id)
+    if not study:
+        print("Study not found or API error.")
+        sys.exit(1)
+
+    print(f"\n  Title:   {study['title']}")
+    print(f"  Sponsor: {study['lead_sponsor']}")
+    print(f"  Docs:    {len(study['docs'])} record(s) found")
+
+    if not study["docs"]:
+        print("\nNo documents are available for this study.")
+        sys.exit(0)
+
+    print("\nAvailable documents:")
+    for doc in study["docs"]:
+        ta = doc.get("typeAbbrev", "?")
+        label = doc.get("label", DOC_TYPE_LABELS.get(ta, ta))
+        print(f"  [{ta}] {label}  ({doc.get('filename', 'no filename')})")
+
+    print(f"\nDownloading to {output_dir / nct_id}/ ...")
+    n = download_study_documents(study, output_dir, args.doc_types)
+    print(f"\n{n} file(s) downloaded.")
+
+
+def cmd_search(args):
+    output_dir = Path(args.output_dir)
+
+    print("\nSearching ClinicalTrials.gov ...")
+    if args.condition:
+        print(f"  Condition:    {args.condition}")
+    if args.intervention:
+        print(f"  Intervention: {args.intervention}")
+    if args.sponsor:
+        print(f"  Sponsor:      {args.sponsor}")
+    print(f"  Doc types:    {', '.join(args.doc_types)}")
+    print(f"  Max studies:  {args.max_studies}")
+
+    studies = search_studies_with_documents(
+        condition=args.condition,
+        intervention=args.intervention,
+        sponsor=args.sponsor,
+        doc_types=args.doc_types,
+        max_studies=args.max_studies,
+    )
+
+    if not studies:
+        print("\nNo matching studies found.")
+        return
+
+    print(f"\nFound {len(studies)} study/studies with documents:\n")
+    for i, study in enumerate(studies, 1):
+        print(f"{i}. {study['nct_id']}: {study['title']}")
+        print(f"   Sponsor: {study['lead_sponsor']}")
+        for doc in study["docs"]:
+            ta = doc.get("typeAbbrev", "?")
+            label = doc.get("label", DOC_TYPE_LABELS.get(ta, ta))
+            print(f"   [{ta}] {label}  ({doc.get('filename', 'no filename')})")
+        print()
+
+    if args.download:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Downloading to {output_dir}/ ...")
+        total = 0
+        for study in studies:
+            print(f"\n{study['nct_id']} - {study['title']}")
+            total += download_study_documents(study, output_dir, args.doc_types)
+        print(f"\nTotal files downloaded: {total}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Download study documents from ClinicalTrials.gov",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    sub = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    # --- download subcommand ---
+    dl = sub.add_parser("download", help="Download documents for a specific NCT ID")
+    dl.add_argument("nct_id", help="NCT identifier, e.g. NCT04280705")
+    dl.add_argument(
+        "--doc-types", nargs="+", choices=["protocol", "sap", "icf"], default=None,
+        help="Limit downloads to these types (default: all available)",
+    )
+    dl.add_argument("--output-dir", default="./clinical_trial_docs",
+                    help="Directory to save files (default: ./clinical_trial_docs)")
+
+    # --- search subcommand ---
+    sr = sub.add_parser("search", help="Search for studies that have uploaded documents")
+    sr.add_argument("--condition",    help="Disease/condition (e.g. 'lung cancer')")
+    sr.add_argument("--intervention", help="Drug/intervention (e.g. 'pembrolizumab')")
+    sr.add_argument("--sponsor",      help="Sponsor name (e.g. 'Pfizer')")
+    sr.add_argument(
+        "--doc-types", nargs="+", choices=["protocol", "sap", "icf"],
+        default=["protocol"],
+        help="Document types to search for (default: protocol)",
+    )
+    sr.add_argument("--max-studies", type=int, default=5,
+                    help="Max studies to return (default: 5)")
+    sr.add_argument("--download", action="store_true",
+                    help="Download the documents after listing them")
+    sr.add_argument("--output-dir", default="./clinical_trial_docs",
+                    help="Directory to save files when --download is used")
+
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    if args.command == "download":
+        cmd_download(args)
+    elif args.command == "search":
+        cmd_search(args)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Searches ClinicalTrials.gov API v2 for studies with uploaded protocol,
SAP, or ICF documents and downloads them as PDFs. Supports lookup by
NCT ID or filtered search by condition, intervention, or sponsor.

https://claude.ai/code/session_01M6SEVc7Y5gerZJ9jtYHwW3